### PR TITLE
fix the decode error bug if the job params has not ascii word

### DIFF
--- a/plan/core.py
+++ b/plan/core.py
@@ -174,7 +174,7 @@ class Plan(object):
         command.append(tmp_cronfile.name)
 
         try:
-            output, error, returncode = communicate_process(command)
+            output, error, returncode = communicate_process(command, encoding='utf-8')
             if returncode != 0:
                 raise PlanError("couldn't write crontab; try running check to "
                                 "ensure your cronfile is valid.")
@@ -199,7 +199,7 @@ class Plan(object):
         if self.user:
             command.extend(["-u", str(self.user)])
         try:
-            r = communicate_process(command, universal_newlines=True)
+            r = communicate_process(command, universal_newlines=True, encoding='utf-8')
             output, error, returncode = r
             if returncode != 0:
                 raise PlanError("couldn't read crontab")


### PR DESCRIPTION
File "/Users/chenzhang/PycharmProjects/threatbook_spider/visual_spider_web/views/slave_views.py", line 74, in make_cron_tasks
        cron.run('update')
      File "/Users/chenzhang/envs/threatbook_spider/lib/python3.6/site-packages/plan/core.py", line 278, in run
        self.update_crontab(run_type)
      File "/Users/chenzhang/envs/threatbook_spider/lib/python3.6/site-packages/plan/core.py", line 221, in update_crontab
        current_crontab = self.read_crontab()
      File "/Users/chenzhang/envs/threatbook_spider/lib/python3.6/site-packages/plan/core.py", line 202, in read_crontab
        r = communicate_process(command, universal_newlines=True)
      File "/Users/chenzhang/envs/threatbook_spider/lib/python3.6/site-packages/plan/utils.py", line 22, in communicate_process
        output, error = p.communicate(stdin)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 843, in communicate
        stdout, stderr = self._communicate(input, endtime, timeout)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 1554, in _communicate
        self.stdout.errors)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 740, in _translate_newlines
        data = data.decode(encoding, errors)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 60898: ordinal not in range(128)