### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/job_definition.rst
+++ b/docs/job_definition.rst
@@ -62,7 +62,7 @@ At value is used to define when the job runs.  It takes the following values::
     sunday, monday, tuesday, wednesday, thursday, friday, saturday
     weekday, weekend (case insensitive)
 
-How about multiple at values, you can do that by using one space to seperate
+How about multiple at values, you can do that by using one space to separate
 multiple values, for example I want to run one job every day at 12:15 and
 12:45, I can define it like this::
 

--- a/docs/run_types.rst
+++ b/docs/run_types.rst
@@ -3,7 +3,7 @@
 Run Types
 =========
 
-There are several mode Plan can run on, you shoud pass the run_type parameter
+There are several mode Plan can run on, you should pass the run_type parameter
 when you run your plan object, check out :meth:`~plan.Plan.run`, for example::
     
     cron = Plan()

--- a/plan/job.py
+++ b/plan/job.py
@@ -171,7 +171,7 @@ class Job(object):
         :param month: this parameter can be the following values:
 
                           jan feb mar apr may jun jul aug sep oct nov dec
-                          and all of those full month names(case insenstive)
+                          and all of those full month names(case insensitive)
                           or <int:n>.month
         """
         if '.' in month:
@@ -189,7 +189,7 @@ class Job(object):
                          sun mon tue wed thu fri sat
                          sunday monday tuesday wednesday thursday friday
                          saturday
-                         weekday weekend(case insenstive)
+                         weekday weekend(case insensitive)
         """
         if week.lower() == "weekday":
             return "1,2,3,4,5"
@@ -304,7 +304,7 @@ class Job(object):
             if moment not in at_map[at_type]:
                 at_map[at_type].append(moment)
 
-        # comma seperate same at_type moments
+        # comma separate same at_type moments
         for at_type, moments in iteritems(at_map):
             moments = map(str, moments)
             pairs[at_type] = ','.join(moments)
@@ -332,7 +332,7 @@ class Job(object):
                                  minute.[0-59], hour.[0-23]
             when every is day of week, can be minute.[0-59], hour.[0-23]
 
-            at can also be multiple at values seperated by one space.
+            at can also be multiple at values separated by one space.
         """
         every_type, every = self.parse_every(), self.every
         ats = self.parse_at()


### PR DESCRIPTION
There are small typos in:
- docs/job_definition.rst
- docs/run_types.rst
- plan/job.py

Fixes:
- Should read `separate` rather than `seperate`.
- Should read `insensitive` rather than `insenstive`.
- Should read `should` rather than `shoud`.
- Should read `separated` rather than `seperated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md